### PR TITLE
Potential fix for code scanning alert no. 11: Information exposure through a stack trace

### DIFF
--- a/app/api/workers/route.ts
+++ b/app/api/workers/route.ts
@@ -95,9 +95,10 @@ export async function GET() {
       status: 200,
     });
   } catch (error: any) {
+    console.error("Failed to fetch workers", error);
     return new Response(
       JSON.stringify({
-        error: escapeHtml(getErrorMessage(error, "Failed to fetch workers")),
+        error: "Failed to fetch workers",
       }),
       { status: 500 }
     );

--- a/lib/error-utils.ts
+++ b/lib/error-utils.ts
@@ -8,7 +8,7 @@ export function getErrorMessage(
 ): string {
   if (error instanceof Error) return error.message;
   if (typeof error === "string") return error;
-  if (isRecord(error) && typeof error.message === "string")
-    return error.message;
+  if (isRecord(error) && typeof (error as Record<string, unknown>).message === "string")
+    return (error as Record<string, unknown>).message as string;
   return fallback;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/MACM18/NNS/security/code-scanning/11](https://github.com/MACM18/NNS/security/code-scanning/11)

To fix the problem, the API should no longer send the raw exception message back to the client. Instead, it should return a generic, non‑sensitive error message (for example, the provided fallback) and log the detailed error server‑side for debugging. This way, even if `error.message` or a string error contains stack trace or SQL details, those details remain in logs and are not exposed over HTTP.

The best fix with minimal impact is:

- Update the `GET` handler’s `catch` block in `app/api/workers/route.ts` so that the response always uses a constant, generic message such as `"Failed to fetch workers"`.
- Optionally, log the detailed error using `console.error` (or any existing logging mechanism) before returning the response, but do not include that detail in the body.
- Optionally, adjust `getErrorMessage` in `lib/error-utils.ts` if it is intended only for internal/logging use; however, to minimize behavior changes across the app, we can leave it as-is and simply stop using it for user-facing responses in this endpoint.

Concretely:

- In `app/api/workers/route.ts`, replace the `catch` block inside `GET` (lines 97–103) so that:
  - It logs `error` server-side.
  - It returns `JSON.stringify({ error: "Failed to fetch workers" })` (or similar), without calling `getErrorMessage` or `escapeHtml`.
- No changes are required to imports or other parts of the file; `getErrorMessage` can still be used elsewhere where appropriate.
- No changes are strictly required in `lib/error-utils.ts` for this fix, since the vulnerability is in how its output is used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
