### PR TITLE
Potential fix for code scanning alert no. 8: Information exposure through a stack trace

### DIFF
--- a/lib/error-utils.ts
+++ b/lib/error-utils.ts
@@ -6,9 +6,15 @@ export function getErrorMessage(
   error: unknown,
   fallback: string = "An unknown error occurred"
 ): string {
-  if (error instanceof Error) return error.message;
-  if (typeof error === "string") return error;
-  if (isRecord(error) && typeof (error as Record<string, unknown>).message === "string")
-    return (error as Record<string, unknown>).message as string;
-  return fallback;
+  // Log the detailed error server-side for debugging purposes.
+  // Do not expose raw error messages or stack traces to the client.
+  try {
+    console.error("Internal error:", error);
+  } catch {
+    // Swallow logging errors to avoid affecting response handling.
+  }
+
+  // Always return the provided fallback message (or a safe default),
+  // ensuring no sensitive details from `error` are leaked to the user.
+  return fallback || "An unknown error occurred";
 }


### PR DESCRIPTION
Potential fix for [https://github.com/MACM18/NNS/security/code-scanning/8](https://github.com/MACM18/NNS/security/code-scanning/8)

In general, to fix this issue we must stop returning raw error messages (which may contain stack traces or sensitive details) to the user. Instead, we should return a generic, non-sensitive message and log the detailed error on the server for debugging.

The best targeted fix here is to change `getErrorMessage` in `lib/error-utils.ts` so that it no longer passes through `error.message` or arbitrary string errors to the caller. Instead, it should always return the provided `fallback` message, while optionally performing a server-side log of the detailed error. This preserves existing behavior where callers provide a specific fallback like `"Failed to update worker"` and expect that text to reach the client, while preventing any unexpected sensitive information from leaking. Since we’re not asked to change logging behavior in `route.ts` and can’t see the rest of the code, we’ll keep the change localized to `lib/error-utils.ts`.

Concretely:
- Update `getErrorMessage` to:
  - Log the full `error` (e.g., via `console.error`) along with some context.
  - Always return `fallback` (or a safe default if `fallback` is missing).
- Leave the callers in `app/api/workers/route.ts` unchanged; they will now automatically send only their generic messages such as `"Failed to update worker"` or `"Failed to delete worker"`.

No changes are needed in `app/api/workers/route.ts` itself, because the information leak is happening via `getErrorMessage` returning detailed error content.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
